### PR TITLE
use a newer version of bson

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   }
 , "dependencies": {
     "async": "*",
-    "bson": "0.2.3",
+    "bson": "0.2.19",
     "coffee-script": "1.4.0",
     "underscore": "*",
     "debug": "*",


### PR DESCRIPTION
version 0.2.3 of bson seems to print `Failed to load c++ bson extension, using pure JS version` but using 0.2.19 doesn't.