### PR TITLE
basic return on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "amqp-coffee"
 , "description" : "AMQP driver for node"
 , "keywords" : [ "amqp" ]
-, "version" : "0.1.19"
+, "version" : "0.1.20"
 , "author" : { "name" : "David Barshow" },
   "licenses": [
     {

--- a/src/lib/Publisher.coffee
+++ b/src/lib/Publisher.coffee
@@ -17,6 +17,9 @@ class Publisher extends Channel
     @seqCallbacks     = {} # publisher confirms
     @confirm          = confirm ? false
 
+    @currentMethod = null
+    @currentArgs   = null
+
     if @confirm then @confirmMode()
     return @
 
@@ -101,8 +104,8 @@ class Publisher extends Channel
 
 
   _onMethod: (channel, method, args)->
-    @previousMethod = method
-    @previousArgs   = args
+    @currentMethod = method
+    @currentArgs   = args
 
     switch method
       when methods.basicAck
@@ -111,10 +114,10 @@ class Publisher extends Channel
           @_gotSeq args.deliveryTag, args.multiple
 
   _onContentHeader: (channel, classInfo, weight, properties, size)->
-    switch @previousMethod
+    switch @currentMethod
       when methods.basicReturn
         if properties.headers?['x-seq']?
-          @_gotSeq properties.headers['x-seq'], false, @previousArgs
+          @_gotSeq properties.headers['x-seq'], false, @currentArgs
 
   _onContent: (channel, data)->
     # Content is not needed efen on a basicReturn

--- a/src/lib/Publisher.coffee
+++ b/src/lib/Publisher.coffee
@@ -41,8 +41,7 @@ class Publisher extends Channel
 
     if @confirm then @confirmMode()
 
-  publish: (exchange, routingKey, data, options, cb)=>
-
+  publish: (exchange, routingKey, data, options, cb)->
     if typeof options is 'function'
       cb = options
       options = {}
@@ -101,7 +100,7 @@ class Publisher extends Channel
       cb() if cb?
 
 
-  _onMethod: (channel, method, args)=>
+  _onMethod: (channel, method, args)->
     @previousMethod = method
     @previousArgs   = args
 
@@ -111,7 +110,7 @@ class Publisher extends Channel
           # debug 4, ()=> return JSON.stringify args
           @_gotSeq args.deliveryTag, args.multiple
 
-  _onContentHeader: (channel, classInfo, weight, properties, size)=>
+  _onContentHeader: (channel, classInfo, weight, properties, size)->
     switch @previousMethod
       when methods.basicReturn
         if properties.headers?['x-seq']?
@@ -120,7 +119,7 @@ class Publisher extends Channel
   _onContent: (channel, data)->
     # Content is not needed efen on a basicReturn
 
-  _waitForSeq: (seq, cb)=>
+  _waitForSeq: (seq, cb)->
     if typeof cb is 'function'
       @seqCallbacks[seq] = cb
     else

--- a/test/queue.test.coffee
+++ b/test/queue.test.coffee
@@ -621,3 +621,32 @@ describe 'Queue', () ->
 
     ], done
 
+
+
+  it 'test we get a error on a bad bind', (done)->
+    amqp = null
+    queue = null
+    queueName = uuid()
+    channel = null
+    async.series [
+      (next)->
+        amqp = new AMQP {host:'localhost'}, (e, r)->
+          should.not.exist e
+          next()
+
+      (next)->
+        channel = amqp.queue {queue:queueName}, (e, q)->
+          should.not.exist e
+          should.exist q
+          queue = q
+          next()
+
+
+      (next)->
+        queue.bind "amq.direct", "testing", (e,r)->
+          should.exist e
+          e.replyCode.should.eql 404
+          next()
+
+    ], done
+


### PR DESCRIPTION
* use message headers to confirm publishes with error on a basicReturn use for mandatory or immediate