### PR TITLE
upgraded bson, switched to prepublish coffee-script compile

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+/.DS_Store
+/coverage.html
+/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - "0.12"
   - "0.10"
   - "0.8"
+  - "iojs"
 services: rabbitmq

--- a/package.json
+++ b/package.json
@@ -12,17 +12,17 @@
 , "main": "./bin/src/amqp.js"
 , "scripts": {
     "test": "./scripts/test.sh",
-    "install": "./scripts/compile.sh"
+    "prepublish": "./scripts/compile.sh"
   }
 , "dependencies": {
     "async": "*",
-    "bson": "0.2.19",
-    "coffee-script": "1.4.0",
+    "bson": "~0.3.2",
     "underscore": "*",
     "debug": "*",
     "node-uuid": "*"
   } ,
   "devDependencies":{
+    "coffee-script": "1.4.0",
     "istanbul"   : "0.1.43",
     "jscoverage" : "0.3.8",
     "mocha": "*",


### PR DESCRIPTION
* added iojs as a test platform
* compile pre-publish to npm and removed coffee-script as a dep
* upgraded bson