### PR TITLE
fixed shared options object on publish

### DIFF
--- a/src/lib/Publisher.coffee
+++ b/src/lib/Publisher.coffee
@@ -49,7 +49,9 @@ class Publisher extends Channel
       cb = options
       options = {}
 
-    if !options? then options = {}
+    # Because we add modify options, we want to make sure we only modify our internal version
+    # this is why we clone it.
+    if !options? then options = {} else options = _.clone options
 
     if @state isnt "open" or (@confirm and @confirmState isnt "open")
       if @state is "opening" or @state is "closed" or (@confirm and @confirmState is 'opening')


### PR DESCRIPTION
* fixed bug that could lead to publshing to the wrong routing key if messages where queued quickly and options was a shared object between the publishes