### PR TITLE
fix(serializationHelpers): require util to prevent crash

### DIFF
--- a/src/lib/serializationHelpers.coffee
+++ b/src/lib/serializationHelpers.coffee
@@ -1,4 +1,5 @@
 jspack = require('../jspack')
+util = requrie('util')
 
 exports.serializeFloat = serializeFloat = (b, size, value, bigEndian)->
   jp = new jspack(bigEndian)

--- a/src/lib/serializationHelpers.coffee
+++ b/src/lib/serializationHelpers.coffee
@@ -1,5 +1,5 @@
 jspack = require('../jspack')
-util = requrie('util')
+util = require('util')
 
 exports.serializeFloat = serializeFloat = (b, size, value, bigEndian)->
   jp = new jspack(bigEndian)


### PR DESCRIPTION
Fixes crash at util.isArray when serializing clientProperties

```
/Users/vitaly/projects/ms-amqp-transport/node_modules/amqp-coffee/bin/src/lib/serializationHelpers.js:140
        } else if (util.isArray(value)) {
                   ^

ReferenceError: util is not defined
    at exports.serializeValue.serializeValue (amqp-coffee/bin/src/lib/serializationHelpers.js:140:20)
    at exports.serializeTable.serializeTable (amqp-coffee/bin/src/lib/serializationHelpers.js:163:7)
    at exports.serializeFields.serializeFields amqp-coffee/bin/src/lib/serializationHelpers.js:272:25)
    at Connection._sendMethod (amqp-coffee/bin/src/lib/Connection.js:525:7)
    at Connection._sendMethod (amqp-coffee/bin/src/lib/Connection.js:4:61)
    at Connection._onMethod (amqp-coffee/bin/src/lib/Connection.js:682:25)
    at AMQPParser.<anonymous> (amqp-coffee/bin/src/lib/Connection.js:4:61)
    at emitThree (events.js:97:13)
    at AMQPParser.emit (events.js:175:7)
    at AMQPParser.parseMethodFrame (amqp-coffee/bin/src/lib/AMQPParser.js:111:19)
    at AMQPParser.frameEnd (amqp-coffee/bin/src/lib/AMQPParser.js:81:16)
    at AMQPParser.frame (amqp-coffee/bin/src/lib/AMQPParser.js:64:21)
    at AMQPParser.header (amqp-coffee/bin/src/lib/AMQPParser.js:51:21)
    at AMQPParser.execute (amqp-coffee/bin/src/lib/AMQPParser.js:31:33)
    at Socket.<anonymous> (amqp-coffee/bin/src/lib/Connection.js:497:29)
    at emitOne (events.js:77:13)
```