### PR TITLE
Test against Node.js v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "7"
   - "6"
   - "5"
   - "5.1"


### PR DESCRIPTION
Also note that Node.js v0.10, and Node.js v5 (and iojs for that matter) are now officially out of support. If you want these removed, I'd be happy to oblige.