### PR TITLE
Use uuid package. Fixes #67

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "async": "*",
     "bson": "~0.4.21",
     "debug": "*",
-    "node-uuid": "*",
     "underscore": "*"
   },
   "devDependencies": {
@@ -32,7 +31,8 @@
     "istanbul": "0.1.43",
     "jscoverage": "0.3.8",
     "mocha": "2.5.3",
-    "should": "*"
+    "should": "*",
+    "uuid": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/consumer.test.coffee
+++ b/test/consumer.test.coffee
@@ -2,7 +2,7 @@ should  = require('should')
 async    = require('async')
 _        = require('underscore')
 proxy    = require('./proxy')
-uuid = require('node-uuid').v4
+uuid = require('uuid').v4
 
 AMQP = require('src/amqp')
 

--- a/test/exchange.test.coffee
+++ b/test/exchange.test.coffee
@@ -2,7 +2,7 @@ should  = require('should')
 async    = require('async')
 _        = require('underscore')
 proxy    = require('./proxy')
-uuid = require('node-uuid').v4
+uuid = require('uuid').v4
 
 AMQP = require('src/amqp')
 

--- a/test/publish.test.coffee
+++ b/test/publish.test.coffee
@@ -2,7 +2,7 @@ should  = require('should')
 async    = require('async')
 _        = require('underscore')
 proxy    = require('./proxy')
-uuid = require('node-uuid').v4
+uuid = require('uuid').v4
 
 AMQP = require('src/amqp')
 

--- a/test/queue.test.coffee
+++ b/test/queue.test.coffee
@@ -2,7 +2,7 @@ should  = require('should')
 async    = require('async')
 _        = require('underscore')
 proxy    = require('./proxy')
-uuid = require('node-uuid').v4
+uuid = require('uuid').v4
 
 AMQP = require('src/amqp')
 

--- a/test/rabbit.test.coffee
+++ b/test/rabbit.test.coffee
@@ -3,7 +3,7 @@ async    = require('async')
 _        = require('underscore')
 Proxy    = require('./proxy')
 
-uuid = require('node-uuid').v4
+uuid = require('uuid').v4
 
 AMQP = require('src/amqp')
 


### PR DESCRIPTION
This fixes two issues:

1. Issue #67 where `uuid` replaces `node-uuid`
1. The uuid package appears to be only used in tests, so I made it a dev dependency