### PR TITLE
perf: disable nagle

### DIFF
--- a/src/lib/Connection.coffee
+++ b/src/lib/Connection.coffee
@@ -132,6 +132,12 @@ class Connection extends EventEmitter
         else
           @connection = net.connect @connectionOptions.port, @connectionOptions.host
           setupConnectionListeners()
+        
+        if 'setNoDelay' in @connection
+          @connection.setNoDelay()
+
+        if 'socket' in @connection and 'setNoDelay' in @connection.socket
+          @connection.socket.setNoDelay()
 
         # start listening for timeouts
 

--- a/src/lib/Connection.coffee
+++ b/src/lib/Connection.coffee
@@ -133,11 +133,8 @@ class Connection extends EventEmitter
           @connection = net.connect @connectionOptions.port, @connectionOptions.host
           setupConnectionListeners()
         
-        if 'setNoDelay' in @connection
+        if @connectionOptions.noDelay
           @connection.setNoDelay()
-
-        if 'socket' in @connection and 'setNoDelay' in @connection.socket
-          @connection.socket.setNoDelay()
 
         # start listening for timeouts
 

--- a/src/lib/defaults.coffee
+++ b/src/lib/defaults.coffee
@@ -28,6 +28,7 @@ module.exports =
     connectTimeout: 30000 # in ms
     channelMax: 0 # unlimited
     frameMax: MaxFrameSize
+    noDelay: true # disable Nagle's algorithm by default
 
     temporaryChannelTimeout: 2000 # in ms
     temporaryChannelTimeoutCheck: 1000 # in ms


### PR DESCRIPTION
this decreases latency per message by a factor of 20 to 40 based on the platform/network stack used, for me it drops 11 ms per message to 0.3ms