### PR TITLE
Add `arguments` to queue constructor options in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The `queueOptions` argument should be an object which specifies:
 * `exclusive`: default: false. The queue can only be used by the current connection.
 * `durable`: default: false
 * `passive`: default: false.  The queue creation will not fail if the queue already exists.
+* `arguments`: default: {}. Pass queue configuartion arguments, e.g. `'x-dead-letter-exchange'`.
 
 Both queues and exchanges use "temporary" channels, which are channels amqp-coffee manages specifically for declaring, binding, unbinding, and deleting queues and exchanges.  After 2 seconds of inactivity these channels are closed, and reopened on demand.
 


### PR DESCRIPTION
On the `queueOptions`, an `arguments` property is accepted which gets used for queue configuration, e.g. setting up a [dead letter exchange](https://www.rabbitmq.com/dlx.html). In this commit I added that existing functionality to the README.