### PR TITLE
Add checking if options.contentType was not specified

### DIFF
--- a/src/lib/Publisher.coffee
+++ b/src/lib/Publisher.coffee
@@ -64,28 +64,31 @@ class Publisher extends Channel
       else
         return cb("Channel is closed and will not re-open? #{@state} #{@confirm} #{@confirmState}") if cb
 
-    # data must be a buffer
-    if typeof data is 'string'
-      options.contentType = 'string/utf8'
-      data = new Buffer(data, 'utf8')
+    # check type of data only if options.contentType was not specified
+    if !options.contentType?
 
-    else if typeof data is 'object' and !(data instanceof Buffer)
-      if options.contentType?
-        debug 1, ()=> return "contentType specified but data isn't a buffer, #{JSON.stringify options}"
-        if cb?
-          cb("contentType specified but data isn't a buffer")
-          return
+      # data must be a buffer
+      if typeof data is 'string'
+        options.contentType = 'string/utf8'
+        data = new Buffer(data, 'utf8')
 
-      # default use JSON
-      data = new Buffer(JSON.stringify(data), 'utf8')
-      options.contentType = 'application/json'
+      else if typeof data is 'object' and !(data instanceof Buffer)
+        if options.contentType?
+          debug 1, ()=> return "contentType specified but data isn't a buffer, #{JSON.stringify options}"
+          if cb?
+            cb("contentType specified but data isn't a buffer")
+            return
 
-      # data = BSON.serialize data
-      # options.contentType = 'application/bson'
+        # default use JSON
+        data = new Buffer(JSON.stringify(data), 'utf8')
+        options.contentType = 'application/json'
 
-    else if data is undefined
-      data = new Buffer(0)
-      options.contentType = 'application/undefined'
+        # data = BSON.serialize data
+        # options.contentType = 'application/bson'
+
+      else if data is undefined
+        data = new Buffer(0)
+        options.contentType = 'application/undefined'
 
 
     # increment this as the final step before publishing, to make sure we're in sync with the server

--- a/test/publish.test.coffee
+++ b/test/publish.test.coffee
@@ -485,4 +485,31 @@ describe 'Publisher', () ->
       # console.error "DONE AT THE END HERE", err, res
       should.not.exist err
 
+  it 'test we can publish a message with any contentType', (done)->
+    amqp = null
+    queue = uuid()
+    testData = "test message"
+    testContentType = 'plain\text'
 
+    messageProcessor = (m)->
+      m.data.should.eql testData
+      m.contentType.should.eql testContentType
+      done()
+
+    async.series [
+      (next)->
+        amqp = new AMQP {host:'localhost'}, (e, r)->
+          should.not.exist e
+          next()
+
+      (next)->
+        amqp.publish "amq.direct", queue, testData, {confirm:true, contentType:testContentType}, (e,r)->
+          should.not.exist e
+          next()
+
+      (next)->
+        amqp.consume queue, {}, messageProcessor, (e,r)->
+          should.not.exist e
+          next()
+
+    ], done


### PR DESCRIPTION
Add checking if options.contentType was not specified before checking data types to allow using any MIME types for messages.